### PR TITLE
new PORTULAN data; all recommendations now hooked to Schematron and using `registryLink` instead of `a`; plus schemas, plus basic visualisation of single vs. multiple `registryLink`

### DIFF
--- a/SIS/clarin/data/domains.xml
+++ b/SIS/clarin/data/domains.xml
@@ -68,6 +68,10 @@
         <desc>Structured or unstructured descriptions of linguistic varieties or phenomena, typological databases etc.</desc>
     </domain>
     <domain id="17" orderBy="Uncategorized">
+        <name>Packaging</name>
+        <desc>Packaging formats of various nature (archiving, compression, library) if no more specific domain is suitable.</desc>
+    </domain>
+    <domain id="18" orderBy="Uncategorized">
         <name>Other</name>
         <desc>Any other function that cannot be included in an existing domain. The content of this domain will be periodically examined for potential patterns that may give rise to new domains.</desc>
     </domain>

--- a/SIS/clarin/data/recommendations/ACDH-ARCHE-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ACDH-ARCHE-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="ACDH-ARCHE" deposition="1">
         <name>Austrian Centre for Digital Humanities and Cultural Heritage - A Resource Centre for the Humanities</name>
-        <a href="https://centres.clarin.eu/centre/45"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/45"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/ACDH-ARCHE-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ACDH-ARCHE-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="ACDH-ARCHE" deposition="1">
         <name>Austrian Centre for Digital Humanities and Cultural Heritage - A Resource Centre for the Humanities</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/45"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/45"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/BAS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/BAS-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="BAS" deposition="1">
         <name>Bayerisches Archiv für Sprachsignale</name>
-        <a href="https://centres.clarin.eu/centre/5"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/5"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
           <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/BAS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/BAS-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="BAS" deposition="1">
         <name>Bayerisches Archiv für Sprachsignale</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/5"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/5"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
           <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/BBAW-recommendation.xml
+++ b/SIS/clarin/data/recommendations/BBAW-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="BBAW" deposition="1">
         <name>Berlin-Brandenburg Academy of Sciences and Humanities</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/6"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/6"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
           <ri status="Collections, Lexical Resources, Editions">Text+</ri>

--- a/SIS/clarin/data/recommendations/BBAW-recommendation.xml
+++ b/SIS/clarin/data/recommendations/BBAW-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="BBAW" deposition="1">
         <name>Berlin-Brandenburg Academy of Sciences and Humanities</name>
-        <a href="https://centres.clarin.eu/centre/6"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/6"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
           <ri status="Collections, Lexical Resources, Editions">Text+</ri>

--- a/SIS/clarin/data/recommendations/CEDIFOR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CEDIFOR-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CEDIFOR" deposition="1">
         <name>Centre for the Digital Foundation of Research in the Humanities, Social, and Educational Sciences</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/35"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/35"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CEDIFOR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CEDIFOR-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CEDIFOR" deposition="1">
         <name>Centre for the Digital Foundation of Research in the Humanities, Social, and Educational Sciences</name>
-        <a href="https://centres.clarin.eu/centre/35"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/35"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CELR-EKK-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CELR-EKK-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CELR-EKK" deposition="1">
         <name>Center of Estonian Language Resources</name>
-        <a href="https://centres.clarin.eu/centre/15"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/15"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CELR-EKK-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CELR-EKK-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CELR-EKK" deposition="1">
         <name>Center of Estonian Language Resources</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/15"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/15"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-CH-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-CH-recommendation.xml
@@ -14,8 +14,8 @@
         </respStmt>
         <centre id="CLARIN-CH" deposition="1">
             <name>CLARIN Switzerland</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/80" label="CLARIN-CH-LiRI"/>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/81" label="CLARIN-CH-LaRS"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/80" label="CLARIN-CH-LiRI"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/81" label="CLARIN-CH-LaRS"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-CH-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-CH-recommendation.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
+    <header>
+        <lastUpdateCommitID></lastUpdateCommitID>
+        <filter>
+            <centreID>CLARIN-CH</centreID>
+        </filter>
+        <respStmt>
+            <name><!--for multiple curators, use multiple respStmt elements, each with a resp--></name>
+            <resp><!--optionally specify the range of responsibility; useful if multiple respStmt are used--></resp>
+            <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
+            <reviewDate>0001-01-01</reviewDate>
+        </respStmt>
+        <centre id="CLARIN-CH" deposition="1">
+            <name>CLARIN Switzerland</name>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/80" label="CLARIN-CH-LiRI"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/81" label="CLARIN-CH-LaRS"/>
+            <nodeInfo>
+                <ri status="B-centre">CLARIN</ri>
+            </nodeInfo>
+        </centre>
+    </header>
+    <info><p>For starters, see <a href="https://clarin-ch.ch/start">https://clarin-ch.ch/start</a></p></info>
+    <formats><!--
+            This template will assist in adjusting/creating a recommendations document if you don't
+            have access to a schema-aware XML editor. Copy the XML fragment, 
+            *  adjust the format ID (see https://clarin.ids-mannheim.de/standards/views/list-formats.xq ),
+            *  adjust the domain (https://clarin.ids-mannheim.de/standards/views/list-domains.xq ),
+            *  adjust the recommendation level ({ recommended, acceptable, discouraged }),
+            *  repeat as necessary;
+            *  submit the result as a PR against https://github.com/clarin-eric/standards/tree/formats .
+            
+            <format id="null">
+                <domain>Audiovisual Annotation</domain>
+                <level>recommended</level>
+            </format> 
+        -->
+    </formats>
+</recommendation>

--- a/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
    <centre id="CLARIN-DK-UCPH" deposition="1">
         <name>The CLARIN Centre at the University of Copenhagen</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/14"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/14"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
    <centre id="CLARIN-DK-UCPH" deposition="1">
         <name>The CLARIN Centre at the University of Copenhagen</name>
-        <a href="https://centres.clarin.eu/centre/14"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/14"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN:EL" deposition="1">
         <name>CLARIN:EL National Infrastructure for Language Resources and Technologies in Greece</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/75"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/75"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
@@ -12,7 +12,7 @@
             <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
             <reviewDate>0001-01-01</reviewDate>
         </respStmt>
-        <centre id="CLARIN-EL">
+        <centre id="CLARIN:EL">
         <name>CLARIN:EL National Infrastructure for Language Resources and Technologies in Greece</name>
         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/75"/>
         <nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
@@ -12,7 +12,7 @@
             <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
             <reviewDate>0001-01-01</reviewDate>
         </respStmt>
-        <centre id="CLARIN:EL">
+        <centre id="CLARIN:EL" deposition="1">
         <name>CLARIN:EL National Infrastructure for Language Resources and Technologies in Greece</name>
         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/75"/>
         <nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-EL-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-EL">
         <name>CLARIN:EL National Infrastructure for Language Resources and Technologies in Greece</name>
-        <a href="https://centres.clarin.eu/centre/75"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/75"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-IS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-IS-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-IS" deposition="1">
         <name>CLARIN-IS (Árni Magnússon Institute for Icelandic Studies)</name>
-        <a href="https://centres.clarin.eu/centre/64"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/64"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-IS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-IS-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-IS" deposition="1">
         <name>CLARIN-IS (Árni Magnússon Institute for Icelandic Studies)</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/64"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/64"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-LT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-LT-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-LT" deposition="1">
         <name>CLARIN-LT</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/36"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/36"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-LT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-LT-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-LT" deposition="1">
         <name>CLARIN-LT</name>
-        <a href="https://centres.clarin.eu/centre/36"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/36"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-LV-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-LV-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-LV">
         <name>CLARIN Centre of Latvian language resources and tools</name>
-        <a href="https://centres.clarin.eu/centre/68"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/68"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-LV-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-LV-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-LV">
         <name>CLARIN Centre of Latvian language resources and tools</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/68"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/68"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-PL1-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-PL1-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-PL1" deposition="1">
         <name>CLARIN-PL Language Technology Centre</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/25"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/25"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN-PL1-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-PL1-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="CLARIN-PL1" deposition="1">
         <name>CLARIN-PL Language Technology Centre</name>
-        <a href="https://centres.clarin.eu/centre/25"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/25"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
    <centre id="CLARIN.SI" deposition="1">
         <name>CLARIN.SI Language Technology Centre</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/30"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/30"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>00fb8bd39cea8db57619a65f8f738364ce84dfef</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
    <centre id="CLARIN.SI" deposition="1">
         <name>CLARIN.SI Language Technology Centre</name>
-        <a href="https://centres.clarin.eu/centre/30"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/30"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN.SI-recommendation.xml
@@ -210,7 +210,7 @@
          <level>recommended</level>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fJS">
@@ -218,7 +218,7 @@
          <level>recommended</level>
       </format>
       <format id="fTAR">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fXSD">
@@ -230,7 +230,7 @@
          <level>recommended</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
    </formats>

--- a/SIS/clarin/data/recommendations/CLARINO_Bergen-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARINO_Bergen-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -12,7 +13,7 @@
       </respStmt>
       <centre id="CLARINO_Bergen" deposition="1">
         <name>CLARINO Bergen Center</name>
-        <a href="https://centres.clarin.eu/centre/29"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/29"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLARINO_Bergen-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARINO_Bergen-recommendation.xml
@@ -13,7 +13,7 @@
       </respStmt>
       <centre id="CLARINO_Bergen" deposition="1">
         <name>CLARINO Bergen Center</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/29"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/29"/>
         <nodeInfo>
           <ri status="B-centre,K-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLST-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLST-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="CLST" deposition="1">
          <name>Centre for Language and Speech Technology</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/40"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/40"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/CLST-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLST-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="CLST" deposition="1">
          <name>Centre for Language and Speech Technology</name>
-         <a href="https://centres.clarin.eu/centre/40"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/40"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/CMU-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CMU-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="CMU" deposition="1">
          <name>CMU-TalkBank</name>
-         <a href="https://centres.clarin.eu/centre/18"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/18"/>
          <nodeInfo>
             <ri status="B-centre,K-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/CMU-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CMU-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="CMU" deposition="1">
          <name>CMU-TalkBank</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/18"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/18"/>
          <nodeInfo>
             <ri status="B-centre,K-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/COCOON-recommendation.xml
+++ b/SIS/clarin/data/recommendations/COCOON-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="COCOON" deposition="1">
          <name>Collections de corpus oraux numeriques </name>
-         <a href="https://centres.clarin.eu/centre/33"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/33"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/COCOON-recommendation.xml
+++ b/SIS/clarin/data/recommendations/COCOON-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="COCOON" deposition="1">
          <name>Collections de corpus oraux numeriques </name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/33"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/33"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/DANS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DANS-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="DANS" deposition="1">
          <name>Data Archiving and Networked Services</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/20"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/20"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/DANS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DANS-recommendation.xml
@@ -368,7 +368,7 @@
          <comment>See <a href="https://dans.knaw.nl/en/file-formats/">more info from DANS</a></comment>
       </format>
       <format id="fHDF5">
-         <domain>Other</domain>
+         <domain>Packaging</domain>
          <level>acceptable</level>
          <comment>See <a href="https://dans.knaw.nl/en/file-formats/">more info from DANS</a></comment>
       </format>

--- a/SIS/clarin/data/recommendations/DANS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DANS-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="DANS" deposition="1">
          <name>Data Archiving and Networked Services</name>
-         <a href="https://centres.clarin.eu/centre/20"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/20"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="DH-REP" deposition="1">
         <name>DARIAH-DE Repository</name>
-        <a href="https://centres.clarin.eu/centre/62"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/62"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
           <ri status="">DARIAH</ri>

--- a/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
@@ -11,7 +11,7 @@
             <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
             <reviewDate>0001-01-01</reviewDate>
         </respStmt>
-        <centre id="DH-REP">
+        <centre id="DH-REP" deposition="1">
         <name>DARIAH-DE Repository</name>
         <a href="https://centres.clarin.eu/centre/62"/>
         <nodeInfo>

--- a/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
+++ b/SIS/clarin/data/recommendations/DH-REP-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="DH-REP" deposition="1">
         <name>DARIAH-DE Repository</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/62"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/62"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
           <ri status="">DARIAH</ri>

--- a/SIS/clarin/data/recommendations/EKUT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/EKUT-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="EKUT" deposition="1">
          <name>Eberhard Karls Universität Tübingen</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/1"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/1"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources">Text+</ri>

--- a/SIS/clarin/data/recommendations/EKUT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/EKUT-recommendation.xml
@@ -139,15 +139,15 @@
          <level>recommended</level>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fRAR">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fTAR">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fXSD">
@@ -159,7 +159,7 @@
          <level>recommended</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
    </formats>

--- a/SIS/clarin/data/recommendations/EKUT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/EKUT-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>769a30e1aa1d88ca6ff632af0047b829055fbe76</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="EKUT" deposition="1">
          <name>Eberhard Karls Universität Tübingen</name>
-         <a href="https://centres.clarin.eu/centre/1"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/1"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources">Text+</ri>

--- a/SIS/clarin/data/recommendations/ELAR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ELAR-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID></lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="ELAR" deposition="1">
         <name>Endangered Languages Archive</name>
-        <a href="https://centres.clarin.eu/centre/36"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/36"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/ELAR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ELAR-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="ELAR" deposition="1">
         <name>Endangered Languages Archive</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/36"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/36"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/ERCC-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ERCC-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="ERCC" deposition="1">
         <name>Eurac Research CLARIN Centre</name>
-        <a href="https://centres.clarin.eu/centre/49"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/49"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/ERCC-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ERCC-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="ERCC" deposition="1">
         <name>Eurac Research CLARIN Centre</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/49"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/49"/>
         <nodeInfo>
           <ri status="C-centre aiming-for-B">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
@@ -13,7 +13,7 @@
       </respStmt>
       <centre id="FIN-CLARIN" deposition="1">
         <name>The Language Bank of Finland</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/17"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/17"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>f1792b82c36aa7632083ff91179330ea69df52b8</lastUpdateCommitID>
@@ -12,7 +13,7 @@
       </respStmt>
       <centre id="FIN-CLARIN" deposition="1">
         <name>The Language Bank of Finland</name>
-        <a href="https://centres.clarin.eu/centre/17"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/17"/>
         <nodeInfo>
           <ri status="B-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/FIN-CLARIN-recommendation.xml
@@ -168,15 +168,15 @@
          <comment>25 fps, 1920×1080, constant bit rate </comment>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>acceptable</level>
       </format>
       <format id="fTAR">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>acceptable</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fMarkdown">

--- a/SIS/clarin/data/recommendations/FZJ-recommendation.xml
+++ b/SIS/clarin/data/recommendations/FZJ-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="FZJ">
         <name>Forschungzentrum Jülich</name>
-        <a href="https://centres.clarin.eu/centre/7"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/7"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
           <ri status="Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/FZJ-recommendation.xml
+++ b/SIS/clarin/data/recommendations/FZJ-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="FZJ">
         <name>Forschungzentrum Jülich</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/7"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/7"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
           <ri status="Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/GEI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/GEI-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="GEI">
         <name>Georg Eckert Institute for International Textbook Research</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/60"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/60"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/GEI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/GEI-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="GEI">
         <name>Georg Eckert Institute for International Textbook Research</name>
-        <a href="https://centres.clarin.eu/centre/60"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/60"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/GWDG-recommendation.xml
+++ b/SIS/clarin/data/recommendations/GWDG-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="GWDG">
         <name>Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen</name>
-        <a href="https://centres.clarin.eu/centre/8"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/8"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
           <ri status="Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/GWDG-recommendation.xml
+++ b/SIS/clarin/data/recommendations/GWDG-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="GWDG">
         <name>Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/8"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/8"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
           <ri status="Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/HZSK-recommendation.xml
+++ b/SIS/clarin/data/recommendations/HZSK-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="HZSK" deposition="1">
          <name>Hamburger Zentrum für Sprachkorpora</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/9"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/9"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/HZSK-recommendation.xml
+++ b/SIS/clarin/data/recommendations/HZSK-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="HZSK" deposition="1">
          <name>Hamburger Zentrum für Sprachkorpora</name>
-         <a href="https://centres.clarin.eu/centre/9"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/9"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/Huygens-recommendation.xml
+++ b/SIS/clarin/data/recommendations/Huygens-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="Huygens">
         <name>Huygens ING</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/21"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/21"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/Huygens-recommendation.xml
+++ b/SIS/clarin/data/recommendations/Huygens-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="Huygens">
         <name>Huygens ING</name>
-        <a href="https://centres.clarin.eu/centre/21"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/21"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/IDS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IDS-recommendation.xml
@@ -18,7 +18,7 @@
       </respStmt>
       <centre id="IDS" deposition="1">
          <name>Leibniz-Institut für Deutsche Sprache</name>
-         <a href="https://centres.clarin.eu/centre/11"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/11"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources, Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/IDS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IDS-recommendation.xml
@@ -18,7 +18,7 @@
       </respStmt>
       <centre id="IDS" deposition="1">
          <name>Leibniz-Institut für Deutsche Sprache</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/11"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/11"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources, Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="ILC4CLARIN" deposition="1">
          <name>The ILC4CLARIN Centre at the Institute for Computational Linguistics</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/34"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/34"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
@@ -90,11 +90,11 @@
          <level>recommended</level>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
    </formats>

--- a/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ILC4CLARIN-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="ILC4CLARIN" deposition="1">
          <name>The ILC4CLARIN Centre at the Institute for Computational Linguistics</name>
-         <a href="https://centres.clarin.eu/centre/34"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/34"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/IMS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IMS-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="IMS" deposition="1">
             <name>Institut für Maschinelle Sprachverarbeitung</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/10"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/10"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/IMS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IMS-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="IMS" deposition="1">
             <name>Institut für Maschinelle Sprachverarbeitung</name>
-            <a href="https://centres.clarin.eu/centre/10"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/10"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/IVDNT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IVDNT-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="IVDNT" deposition="1">
             <name>Instituut voor de Nederlandse Taal</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/22"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/22"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/IVDNT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/IVDNT-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="IVDNT" deposition="1">
             <name>Instituut voor de Nederlandse Taal</name>
-            <a href="https://centres.clarin.eu/centre/22"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/22"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/LAC-recommendation.xml
+++ b/SIS/clarin/data/recommendations/LAC-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>00eb783d79fc8243ac47f242eac08b3e08ed90d8</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="LAC" deposition="1">
          <name>Language Archive Cologne</name>
-         <a href="https://centres.clarin.eu/centre/47"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/47"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources">Text+</ri>

--- a/SIS/clarin/data/recommendations/LAC-recommendation.xml
+++ b/SIS/clarin/data/recommendations/LAC-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="LAC" deposition="1">
          <name>Language Archive Cologne</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/47"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/47"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
             <ri status="Collections, Lexical Resources">Text+</ri>

--- a/SIS/clarin/data/recommendations/LINDAT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/LINDAT-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="LINDAT" deposition="1">
             <name>LINDAT/CLARIN</name>
-            <a href="https://centres.clarin.eu/centre/3"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/3"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/LINDAT-recommendation.xml
+++ b/SIS/clarin/data/recommendations/LINDAT-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="LINDAT" deposition="1">
             <name>LINDAT/CLARIN</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/3"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/3"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/MI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MI-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="MI" deposition="1">
          <name>Meertens Instituut/HuC</name>
-         <a href="https://centres.clarin.eu/centre/23"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/23"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/MI-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MI-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="MI" deposition="1">
          <name>Meertens Instituut/HuC</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/23"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/23"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/MMSHs-Phonotheque-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MMSHs-Phonotheque-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="MMSHs-Phonothèque">
         <name>Mediterranean Research Centre for the Humanities' Phonothèque</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/44"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/44"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/MMSHs-Phonotheque-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MMSHs-Phonotheque-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="MMSHs-Phonothèque">
         <name>Mediterranean Research Centre for the Humanities' Phonothèque</name>
-        <a href="https://centres.clarin.eu/centre/44"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/44"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/MPCDF-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MPCDF-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="MPCDF">
         <name>Max Planck Computing and Data Facility</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/12"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/12"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/MPCDF-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MPCDF-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="MPCDF">
         <name>Max Planck Computing and Data Facility</name>
-        <a href="https://centres.clarin.eu/centre/12"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/12"/>
         <nodeInfo>
           <ri status="E-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/MPI-PL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MPI-PL-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="MPI-PL" deposition="1">
          <name>MPI for Psycholinguistics</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/24"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/24"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/MPI-PL-recommendation.xml
+++ b/SIS/clarin/data/recommendations/MPI-PL-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="MPI-PL" deposition="1">
          <name>MPI for Psycholinguistics</name>
-         <a href="https://centres.clarin.eu/centre/24"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/24"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
+++ b/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="NB.NO" deposition="0">
             <name>National Library of Norway</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/31"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/31"/>
             <nodeInfo>
                 <ri status="C-centre aiming-for-B">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
+++ b/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
@@ -11,7 +11,7 @@
             <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
             <reviewDate>0001-01-01</reviewDate>
         </respStmt>
-        <centre id="NB.NO">
+        <centre id="NB.NO" deposition="0">
             <name>National Library of Norway</name>
             <a href="https://centres.clarin.eu/centre/31"/>
             <nodeInfo>

--- a/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
+++ b/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="NB.NO" deposition="0">
             <name>National Library of Norway</name>
-            <a href="https://centres.clarin.eu/centre/31"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/31"/>
             <nodeInfo>
                 <ri status="C-centre aiming-for-B">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
+++ b/SIS/clarin/data/recommendations/NB.NO-recommendation.xml
@@ -11,7 +11,7 @@
             <link><!--URI; GitHub page or any other way to id/contact the curator--></link>
             <reviewDate>0001-01-01</reviewDate>
         </respStmt>
-        <centre id="NB.NO" deposition="0">
+        <centre id="NB.NO">
             <name>National Library of Norway</name>
             <a href="https://centres.clarin.eu/centre/31"/>
             <nodeInfo>
@@ -30,7 +30,7 @@
             *  submit the result as a PR against https://github.com/clarin-eric/standards/tree/formats .
             
             <format id="null">
-                <domain>Audiovisual Annotation</domain>
+                <domain>Audiovisual Annotation</domain>NB.NO-recommendation.xml
                 <level>recommended</level>
             </format> 
         -->

--- a/SIS/clarin/data/recommendations/ORTOLANG-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ORTOLANG-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="ORTOLANG" deposition="1">
          <name>Open Resources and TOols for LANGuage</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/73"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/73"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/ORTOLANG-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ORTOLANG-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="ORTOLANG" deposition="1">
          <name>Open Resources and TOols for LANGuage</name>
-         <a href="https://centres.clarin.eu/centre/73"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/73"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/OTA-recommendation.xml
+++ b/SIS/clarin/data/recommendations/OTA-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -12,7 +13,7 @@
       </respStmt>
       <centre id="OTA" deposition="1">
          <name>Oxford Text Archive</name>
-         <a href="https://centres.clarin.eu/centre/26"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/26"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/OTA-recommendation.xml
+++ b/SIS/clarin/data/recommendations/OTA-recommendation.xml
@@ -13,7 +13,7 @@
       </respStmt>
       <centre id="OTA" deposition="1">
          <name>Oxford Text Archive</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/26"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/26"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/PORTULAN-CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/PORTULAN-CLARIN-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="PORTULAN-CLARIN" deposition="1">
             <name>PORTULAN CLARIN Research Infrastructure for the Science and Technology of Language</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/50"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/50"/>
             <nodeInfo>
                 <ri status="B-centre,K-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/PORTULAN-CLARIN-recommendation.xml
+++ b/SIS/clarin/data/recommendations/PORTULAN-CLARIN-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="PORTULAN-CLARIN" deposition="1">
             <name>PORTULAN CLARIN Research Infrastructure for the Science and Technology of Language</name>
-            <a href="https://centres.clarin.eu/centre/50"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/50"/>
             <nodeInfo>
                 <ri status="B-centre,K-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/PolMine-recommendation.xml
+++ b/SIS/clarin/data/recommendations/PolMine-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="PolMine">
         <name>PolMine Project</name>
-        <a href="https://centres.clarin.eu/centre/38"/>
+        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/38"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/PolMine-recommendation.xml
+++ b/SIS/clarin/data/recommendations/PolMine-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="PolMine">
         <name>PolMine Project</name>
-        <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/38"/>
+        <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/38"/>
         <nodeInfo>
           <ri status="C-centre">CLARIN</ri>
         </nodeInfo>

--- a/SIS/clarin/data/recommendations/SADiLaR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/SADiLaR-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="SADiLaR" deposition="1">
             <name>South African Centre for Digital Language Resources</name>
-            <a href="https://centres.clarin.eu/centre/58"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/58"/>
             <nodeInfo>
                 <ri status="C-centre aiming-for-B">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/SADiLaR-recommendation.xml
+++ b/SIS/clarin/data/recommendations/SADiLaR-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="SADiLaR" deposition="1">
             <name>South African Centre for Digital Language Resources</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/58"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/58"/>
             <nodeInfo>
                 <ri status="C-centre aiming-for-B">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/SAW-recommendation.xml
+++ b/SIS/clarin/data/recommendations/SAW-recommendation.xml
@@ -11,7 +11,7 @@
         </respStmt>
         <centre id="SAW" deposition="1">
             <name>SAW Leipzig</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/4"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/4"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
                 <ri status="Lexical Resources, Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/SAW-recommendation.xml
+++ b/SIS/clarin/data/recommendations/SAW-recommendation.xml
@@ -11,7 +11,7 @@
         </respStmt>
         <centre id="SAW" deposition="1">
             <name>SAW Leipzig</name>
-            <a href="https://centres.clarin.eu/centre/4"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/4"/>
             <nodeInfo>
                 <ri status="B-centre">CLARIN</ri>
                 <ri status="Lexical Resources, Operations">Text+</ri>

--- a/SIS/clarin/data/recommendations/SAW-recommendation.xml
+++ b/SIS/clarin/data/recommendations/SAW-recommendation.xml
@@ -236,7 +236,7 @@
         </format>
         <!-- Uncategorized -->
         <format id="fZIP">
-            <domain>Tool Support</domain>
+            <domain>Packaging</domain>
             <level>recommended</level>
         </format>
     </formats>

--- a/SIS/clarin/data/recommendations/Sprakbanken-recommendation.xml
+++ b/SIS/clarin/data/recommendations/Sprakbanken-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>38a46ffacb783ddf1181f9ec1c2445eff43cf2de</lastUpdateCommitID>
@@ -12,7 +13,7 @@
       </respStmt>
       <centre id="Sprakbanken" deposition="1">
          <name>Språkbanken</name>
-         <a href="https://centres.clarin.eu/centre/37"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/37"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/Sprakbanken-recommendation.xml
+++ b/SIS/clarin/data/recommendations/Sprakbanken-recommendation.xml
@@ -13,7 +13,7 @@
       </respStmt>
       <centre id="Sprakbanken" deposition="1">
          <name>Språkbanken</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/37"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/37"/>
          <nodeInfo>
             <ri status="C-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/TGrep-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TGrep-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="TGrep" deposition="1">
             <name>TextGrid Repository</name>
-            <a href="https://centres.clarin.eu/centre/71"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/71"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/TGrep-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TGrep-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="TGrep" deposition="1">
             <name>TextGrid Repository</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/71"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/71"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/TROLLing-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TROLLing-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="TROLLing" deposition="1">
             <name>The Tromsø Repository of Language and Linguistics</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/48"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/48"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/TROLLing-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TROLLing-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="TROLLing" deposition="1">
             <name>The Tromsø Repository of Language and Linguistics</name>
-            <a href="https://centres.clarin.eu/centre/48"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/48"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/TextLab-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TextLab-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -7,7 +8,7 @@
         </filter>
         <centre id="TextLab">
             <name>CLARINO Text Laboratory Centre</name>
-            <a href="https://centres.clarin.eu/centre/43"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/43"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/TextLab-recommendation.xml
+++ b/SIS/clarin/data/recommendations/TextLab-recommendation.xml
@@ -8,7 +8,7 @@
         </filter>
         <centre id="TextLab">
             <name>CLARINO Text Laboratory Centre</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/43"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/43"/>
             <nodeInfo>
                 <ri status="C-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/UdS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/UdS-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>147cb5ea659a5752efd819898b43da23e00c6a77</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="UdS" deposition="1">
          <name>Universität des Saarlandes</name>
-         <a href="https://centres.clarin.eu/centre/13"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/13"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
             <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/UdS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/UdS-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="UdS" deposition="1">
          <name>Universität des Saarlandes</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/13"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/13"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
             <ri status="Collections">Text+</ri>

--- a/SIS/clarin/data/recommendations/UdS-recommendation.xml
+++ b/SIS/clarin/data/recommendations/UdS-recommendation.xml
@@ -87,11 +87,11 @@
          <level>recommended</level>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
    </formats>

--- a/SIS/clarin/data/recommendations/ZIM-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ZIM-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
    <header>
       <lastUpdateCommitID>769a30e1aa1d88ca6ff632af0047b829055fbe76</lastUpdateCommitID>
@@ -13,7 +14,7 @@
       </respStmt>
       <centre id="ZIM" deposition="1">
          <name>ZIM Centre for Information Modelling</name>
-         <a href="https://centres.clarin.eu/centre/65"/>
+         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/65"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/ZIM-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ZIM-recommendation.xml
@@ -118,7 +118,7 @@
          <level>recommended</level>
       </format>
       <format id="fHDF5">
-         <domain>Lexical Resource</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fBiBTeX">
@@ -198,7 +198,7 @@
          <level>recommended</level>
       </format>
       <format id="fGZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
       <format id="fXSD">
@@ -210,7 +210,7 @@
          <level>recommended</level>
       </format>
       <format id="fZIP">
-         <domain>Tool Support</domain>
+         <domain>Packaging</domain>
          <level>recommended</level>
       </format>
    </formats>

--- a/SIS/clarin/data/recommendations/ZIM-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ZIM-recommendation.xml
@@ -20,7 +20,7 @@
          </nodeInfo>
       </centre>
     </header>
-   <info><!--use p, ul, ol elements here--></info>
+   <info><!--use p, ul, ol elements here--><p>While the list below is not curated, see <a href="https://gams.uni-graz.at/context:gams?mode=about&amp;locale=en#formats">recommendations mentioned by GAMS</a>, which appears to provide the repository service for ZIM.</p></info>
    <formats>
       <format id="fTEISpoken">
          <domain>Audiovisual Annotation</domain>

--- a/SIS/clarin/data/recommendations/ZIM-recommendation.xml
+++ b/SIS/clarin/data/recommendations/ZIM-recommendation.xml
@@ -14,7 +14,7 @@
       </respStmt>
       <centre id="ZIM" deposition="1">
          <name>ZIM Centre for Information Modelling</name>
-         <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/65"/>
+         <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/65"/>
          <nodeInfo>
             <ri status="B-centre">CLARIN</ri>
          </nodeInfo>

--- a/SIS/clarin/data/recommendations/lundlab-recommendation.xml
+++ b/SIS/clarin/data/recommendations/lundlab-recommendation.xml
@@ -14,7 +14,7 @@
         </respStmt>
         <centre id="lundlab" deposition="1">
             <name>Lund University Humanities Lab</name>
-            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/42"/>
+            <registryLink registry="CLARIN" uri="https://centres.clarin.eu/centre/42"/>
             <nodeInfo>
                 <ri status="C-centre, K-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/data/recommendations/lundlab-recommendation.xml
+++ b/SIS/clarin/data/recommendations/lundlab-recommendation.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemas/recommendation.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?> 
 <recommendation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schemas/recommendation.xsd">
     <header>
         <lastUpdateCommitID>bec52cd36a2996677ce07153a19ce774097f9130</lastUpdateCommitID>
@@ -13,7 +14,7 @@
         </respStmt>
         <centre id="lundlab" deposition="1">
             <name>Lund University Humanities Lab</name>
-            <a href="https://centres.clarin.eu/centre/42"/>
+            <registryLink registry="CLARIN CR" uri="https://centres.clarin.eu/centre/42"/>
             <nodeInfo>
                 <ri status="C-centre, K-centre">CLARIN</ri>
             </nodeInfo>

--- a/SIS/clarin/model/centre.xqm
+++ b/SIS/clarin/model/centre.xqm
@@ -51,5 +51,5 @@ declare function centre:get-distinct-research-infrastructures(){
 };
 
 declare function centre:get-deposition-centres($ri){
-    $centre:centres[nodeInfo/ri=$ri and @deposition=1]
+    $centre:centres[nodeInfo/ri=$ri and xs:boolean(@deposition)]
 };

--- a/SIS/clarin/model/recommendation-by-centre.xqm
+++ b/SIS/clarin/model/recommendation-by-centre.xqm
@@ -12,7 +12,8 @@ declare variable $recommendation:format-ids := data($recommendation:centres/form
 declare variable $recommendation:format-abbrs := for $id in $recommendation:format-ids return fn:substring($id,2);
 
 declare function recommendation:get-recommendations-for-centre($id){
-    let $path := concat('/db/apps/clarin/data/recommendations/',$id,"-recommendation.xml")
+    let $convertedId := translate($id,':','-')
+    let $path := concat('/db/apps/clarin/data/recommendations/',$convertedId,"-recommendation.xml")
     return doc($path)/recommendation
 };
 

--- a/SIS/clarin/modules/centre.xql
+++ b/SIS/clarin/modules/centre.xql
@@ -175,15 +175,17 @@ declare function cm:get-centre-info($id, $lang) {
         cm:get-default-info($id)
     
     return
-        cm:parseFormatRef($info)
+        cm:parseFormatRef($info, $id)
 };
 
-declare function cm:parseFormatRef($info) {
+declare function cm:parseFormatRef($info,$id) {
     if ($info)
     then
         (
-        element info {
+        element span {
             $info/@*,
+            attribute {"id"} {concat("desctext",$id)},
+            attribute {"class"} {"desctext"},
             for $node in $info/node()
             return
                 if ($node/self::p)

--- a/SIS/clarin/schemas/recommendation.xsd
+++ b/SIS/clarin/schemas/recommendation.xsd
@@ -67,7 +67,11 @@
         </xs:complexType>
     </xs:element>
     <xs:element name="search" type="xs:string"/>
-    <xs:element name="centreID" type="xs:string"/>
+    <xs:element name="centreID" type="xs:string">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">'shorthand' for the centre that acts as its ID</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="domain">
         <xs:simpleType>
             <xs:restriction base="xs:string">
@@ -208,9 +212,10 @@
     </xs:element>
     <xs:element name="respStmt">
         <xs:annotation>
-            <xs:documentation>This is an element filled with the name of the curator and date of 
-                curation, and used as an official 'stamp' stating that the set of recommendations 
-                is now ready for public consumption. It should be set at inputhons or manually, when receiving subsequent PRs from the given centre.</xs:documentation>
+            <xs:documentation>This is an element filled with the name of the curator and date of
+                curation, and used as an official 'stamp' stating that the set of recommendations is
+                now ready for public consumption. It should be set at inputhons or manually, when
+                receiving subsequent PRs from the given centre.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -224,7 +229,8 @@
     <xs:element name="name" type="xs:string"/>
     <xs:element name="resp" type="xs:string">
         <xs:annotation>
-            <xs:documentation>Optionally specifies the scope of responsibility, if e.g. a centre manages data across different departments.</xs:documentation>
+            <xs:documentation>Optionally specifies the scope of responsibility, if e.g. a centre
+                manages data across different departments.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="link" type="xs:string">
@@ -240,18 +246,65 @@
         </xs:annotation>
     </xs:element>
     <xs:element name="centre">
-        <xs:complexType mixed="true">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">information about the centre</xs:documentation>
+            <xs:appinfo>
+                <sch:pattern xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+                    <sch:rule context="header/centre">
+                        <sch:assert
+                            test="count(../filter/centreID) = 0 or @id = ../filter/centreID/text()"
+                            >The attribute @id of header/centre has to match header/filter/centreID if
+                            the latter is present.</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType mixed="false">
             <xs:sequence>
-                <xs:element name="name" type="xs:string"/>
-                <xs:element ref="a"/>
+                <xs:element name="name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>the full name of the centre</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="registryLink" minOccurs="1" maxOccurs="unbounded"/>
                 <xs:element ref="nodeInfo"/>
             </xs:sequence>
-            <xs:attribute name="id" type="xs:ID" use="required"/>
+            <xs:attribute name="id" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">'shorthand' for the centre that acts as its ID</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="deposition" type="xs:boolean" use="optional" default="false"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="registryLink">
+        <xs:annotation>
+            <xs:documentation>Link to a registry / database, e.g. the CLARIN centre registry; it is
+                assumed that a centre always comes from some catalogue of centres in the given RI. A
+                centre may be part of different registries. If multiple registryLink elements are
+                present sharing an identical attribute @registry, then, for statistical purposes, it
+                is assumed that the described entity is an abstraction (e.g. a consortium) that
+                consists of more than one centre.</xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="uri" use="required" type="xs:anyURI"/>
+                    <xs:attribute name="registry" use="optional" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>Name of the registry being linked to. Default: the
+                                CLARIN centre registry.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="label" use="optional" type="xs:string">
+                        <xs:annotation><xs:documentation>Optional label</xs:documentation></xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:simpleContent>
         </xs:complexType>
     </xs:element>
     <xs:element name="nodeInfo" type="nodeInfoType"/>
     <xs:complexType name="nodeInfoType">
+        
         <xs:sequence>
             <xs:element ref="ri" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -281,12 +334,14 @@
         </xs:complexType>
     </xs:element>
     <xs:element name="format">
+        <xs:annotation>
+            <xs:documentation>The centreID element is only valid for exports from the
+                "recommended formats" list, provided for all centres. It should NOT be
+                used for importing centre recommendations into SIS.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="centreID" minOccurs="0" maxOccurs="1">
-                    <xs:annotation>
-                        <xs:documentation>This element is only valid for exports from the "recommended formats" list, provided for all centres. 
-                            It should NOT be used for importing centre recommendations into SIS.</xs:documentation></xs:annotation>
                 </xs:element>
                 <xs:element ref="domain"/>
                 <xs:element ref="level"/>

--- a/SIS/clarin/schemas/recommendation.xsd
+++ b/SIS/clarin/schemas/recommendation.xsd
@@ -289,11 +289,30 @@
             <xs:simpleContent>
                 <xs:extension base="xs:string">
                     <xs:attribute name="uri" use="required" type="xs:anyURI"/>
-                    <xs:attribute name="registry" use="optional" type="xs:string">
+                    <xs:attribute name="registry" use="required">
                         <xs:annotation>
                             <xs:documentation>Name of the registry being linked to. Default: the
                                 CLARIN centre registry.</xs:documentation>
                         </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="CLARIN CR">
+                                    <xs:annotation>
+                                        <xs:documentation>CLARIN centre registry at https://centres.clarin.eu/</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="Text+ CR">
+                                    <xs:annotation>
+                                        <xs:documentation>Text+ centre registry, informally at https://text-plus.org/vernetzung/daten-kompetenzzentren/</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="DARIAH CR">
+                                    <xs:annotation>
+                                        <xs:documentation>DARIAH list of repositories</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:attribute>
                     <xs:attribute name="label" use="optional" type="xs:string">
                         <xs:annotation><xs:documentation>Optional label</xs:documentation></xs:annotation>

--- a/SIS/clarin/schemas/recommendation.xsd
+++ b/SIS/clarin/schemas/recommendation.xsd
@@ -180,6 +180,12 @@
                             potential patterns that may give rise to new domains.</xs:documentation>
                     </xs:annotation>
                 </xs:enumeration>
+                <xs:enumeration value="Packaging">
+                    <xs:annotation>
+                        <xs:documentation>Packaging formats of various nature (archiving,
+                            compression, storage) if no more specific domain is suitable.</xs:documentation>
+                    </xs:annotation>
+                </xs:enumeration>
                 <xs:enumeration value="Tool Support">
                     <xs:annotation>
                         <xs:documentation>Tool-related formats required for specific functionality

--- a/SIS/clarin/schemas/recommendation.xsd
+++ b/SIS/clarin/schemas/recommendation.xsd
@@ -289,12 +289,12 @@
             <xs:simpleContent>
                 <xs:extension base="xs:string">
                     <xs:attribute name="uri" use="required" type="xs:anyURI"/>
-                    <xs:attribute name="registry" use="required">
+                    <xs:attribute name="registry" use="required" type="ResearchInfrastructures">
                         <xs:annotation>
                             <xs:documentation>Name of the registry being linked to. Default: the
                                 CLARIN centre registry.</xs:documentation>
                         </xs:annotation>
-                        <xs:simpleType>
+<!--                        <xs:simpleType>
                             <xs:restriction base="xs:string">
                                 <xs:enumeration value="CLARIN CR">
                                     <xs:annotation>
@@ -312,7 +312,7 @@
                                     </xs:annotation>
                                 </xs:enumeration>
                             </xs:restriction>
-                        </xs:simpleType>
+                        </xs:simpleType>-->
                     </xs:attribute>
                     <xs:attribute name="label" use="optional" type="xs:string">
                         <xs:annotation><xs:documentation>Optional label</xs:documentation></xs:annotation>

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -25,7 +25,7 @@ let $template := request:get-parameter('template', '')
 let $centre := cm:get-centre($id)
 let $centre-name := $centre/name/text()
 let $centre-link := data($centre/a/@href)
-let $isDepositing := $centre/@deposition
+let $isDepositing := xs:boolean($centre/@deposition) 
 let $centre-ri := $centre/nodeInfo/ri
 
 let $recommendation := cm:get-recommendations($id)

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -136,7 +136,7 @@ else
                                 else ()
                             }
                             {
-                                if ($centre-info)
+                                if ($centre-info/info)
                                 then
                                     <div>
                                         <span class="heading">Description: </span>

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -136,11 +136,11 @@ else
                                 else ()
                             }
                             {
-                                if ($centre-info)
+                                if ($centre-info/*)
                                 then
                                     <div>
                                         <span class="heading">Description: </span>
-                                        <span id="desctext{$id}" class="desctext">{$centre-info}</span>
+                                        {$centre-info}
                                     </div>
                                 else
                                     ()

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -127,7 +127,7 @@ else
                             {
                                 if ($isDepositing)
                                 then 
-                                    cm:print-curation($respStmt,$languageHeader)
+                                    rf:print-curation($recommendation,$languageHeader)
                                 else ()
                             }
                             {

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -145,13 +145,16 @@ else
                                 if (count($domains)>0)
                                 then(
                                     <div>
-                                        <span class="heading">Functional domains: </span>
+                                        <span class="heading">Data functions covered by the recommendations</span>
+                                        <div>
+                                        <span class="desctext">Recommendations provided by this centre concern the following <a href="{app:link('views/list-domains.xq')}">functions of data</a>:</span>
                                             <ul>
                                                 {
                                                     for $d in $domains
                                                     return <li>{$d}</li>
                                                 }
                                             </ul>
+                                        </div>
                                     </div>
                                 )
                                 else ()

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -136,7 +136,7 @@ else
                                 else ()
                             }
                             {
-                                if ($centre-info/info)
+                                if ($centre-info)
                                 then
                                     <div>
                                         <span class="heading">Description: </span>

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -24,7 +24,7 @@ let $template := request:get-parameter('template', '')
 
 let $centre := cm:get-centre($id)
 let $centre-name := $centre/name/text()
-let $centre-link := data($centre/a/@href)
+let $registry-links := $centre/registryLink
 let $isDepositing := xs:boolean($centre/@deposition) 
 let $centre-ri := $centre/nodeInfo/ri
 
@@ -81,10 +81,45 @@ else
                                 <span class="heading">Abbreviation: </span>
                                 <span id="abbrtext" class="heading">{$id}</span>
                             </div>
+                            {
+                            if (count($registry-links) eq 1)
+                            then 
                             <div>
                                 <span class="heading">Link: </span>
-                                <span id="link"><a href="{$centre-link}">{$centre-link}</a></span>
-                            </div>
+                                {
+                                    let $uri := data($registry-links/@uri)
+                                    let $label := 
+                                           if (data($registry-links/@label))
+                                           then
+                                             concat('   (',data($registry-links/@label), ')')
+                                           else () 
+                                     
+                                     return
+                                    <span id="reg-link"><a href="{$uri}">{$uri}</a>{$label}</span>
+                                 }
+
+                             </div>                            
+                             else 
+                             <div>
+                                <span class="heading">Links: </span>
+                                <ul>
+                                {
+                                    for $registry-link at $pos in ($registry-links)
+                                       let $uri := data($registry-link/@uri)
+                                       let $label := 
+                                           if (data($registry-link/@label))
+                                           then
+                                             concat('   (',data($registry-link/@label), ')')
+                                           else () 
+                                    return 
+                                      <li><span id="{concat('reg-link_',$pos)}"><a href="{$uri}">{$uri}</a></span><span id="{concat('reg-label_',$pos)}">{$label}</span></li>
+                                 }
+                                 </ul>
+
+                             </div>
+                            
+                           }
+
                             <div>
                                 <span class="heading">Research infrastructure: </span>
                                 <ul>{cm:print-ri($centre-ri)}</ul>

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -69,6 +69,9 @@ else
                                 &gt; <a href="{app:link(concat("views/view-centre.xq?id=", $id))}">{$centre-name}</a>
                             </div>
                             <div class="title">{$centre-name}</div>
+                            {
+                            if (not(rf:isCurated($respStmt)))
+                            then
                             <div style="float:right;">
                                 <span>
                                     <a href="{cm:getGithubCentreIssueLink($id)}" class="button" 
@@ -77,6 +80,8 @@ else
                                         Suggest a fix or extension</a>
                                 </span>
                             </div>
+                            else ()
+                            }
                             <div>
                                 <span class="heading">Abbreviation: </span>
                                 <span id="abbrtext" class="heading">{$id}</span>
@@ -220,6 +225,19 @@ else
                                             )
                                         else ()
                                 )
+                            }
+                            {
+                            if (rf:isCurated($respStmt))
+                            then
+                            <div style="float:right;">
+                                <span>
+                                    <a href="{cm:getGithubCentreIssueLink($id)}" class="button" 
+                                        style="margin-left:5px; padding: 5px 5px 2px 5px; height:25px;
+                                        color:darkred; border-color:darkred">
+                                        Suggest a fix or extension</a>
+                                </span>
+                            </div>
+                            else ()
                             }
                         </div>
                     else

--- a/SIS/clarin/views/view-centre.xq
+++ b/SIS/clarin/views/view-centre.xq
@@ -171,7 +171,7 @@ else
                                         
                                     <div>
                                         <span class="heading" id="recommendationTable">Recommendations: </span>
-                                        <span>not available</span>
+                                        <span>not yet available in the SIS</span>
                                         <form method="get" action="" style="float: right;">
                                               <input name="template" class="button"
                                               style="margin-bottom:5px; height:25px;width:165px;" 


### PR DESCRIPTION
+ minor fixes and enhancements, in addition to what's in the title.