### PR TITLE
CLARIN-DK-UCPH: use already defined format

### DIFF
--- a/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
+++ b/SIS/clarin/data/recommendations/CLARIN-DK-UCPH-recommendation.xml
@@ -58,7 +58,7 @@
          <domain>Image Source Language Data</domain>
          <level>recommended</level>
       </format>
-      <format id="fVRT">
+      <format id="fCWB-VRT">
          <domain>Language Description</domain>
          <level>recommended</level>
       </format>


### PR DESCRIPTION
I think the already defined fCWB-VRT can be used instead of fVRT, which is undefined.