### PR TITLE
add fTiger

### DIFF
--- a/SIS/clarin/data/formats/fTiger.xml
+++ b/SIS/clarin/data/formats/fTiger.xml
@@ -1,0 +1,21 @@
+<?xml-model href="../../schemas/format.xsd" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<format xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="fTiger" xsi:noNamespaceSchemaLocation="../../schemas/format.xsd" display="show">
+  <titleStmt>
+    <title>TIGER XML</title>
+    <abbr>TIGER</abbr>
+  </titleStmt>
+  <keyword>annotation format</keyword>
+  <keyword>corpus encoding</keyword>
+  <!-- <extId type=""></extId> -->
+  <info type="description">
+    <p>XML format used by the TIGER project.</p>
+    <p>See:</p>
+    <ul>
+      <li><a href="https://www.ims.uni-stuttgart.de/documents/ressourcen/korpora/tiger-corpus/download/start.html">TIGER corpus</a></li>
+      <li><a href="https://www.ims.uni-stuttgart.de/documents/ressourcen/werkzeuge/tigersearch/doc/html/TigerXML.html">TIGER XML</a></li>
+      <li><a href="https://aclanthology.org/L00-1042/">TIGER XML</a></li>
+    </ul>
+  </info>
+  <fileExt>.xml</fileExt>
+  <formatFamily>XML</formatFamily>
+</format>


### PR DESCRIPTION
I added a format definition for Tiger XML.

I just stumbled over the format while translating our PDF recommendations into SIS recommendations. However, after the discussion in #341, I am not sure whether it should have its own entry. At the moment, there seem to be three references to fTiger. I am pretty sure our center will not insist on Tiger XML, but I cannot consult the author of our original recommendations at the moment. I don't think Tiger XML is very popular any more.

Also, there is a dialect of Tiger XML (Tiger/SALSA XML). How should I deal with that?