### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/SIS/clarin/resources/scripts/edit.js
+++ b/SIS/clarin/resources/scripts/edit.js
@@ -7,6 +7,15 @@ if (typeof String.prototype.startsWith != 'function') {
     };
 }
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function showResp(resptype,resporg,respname){
 	e = document.getElementById(resptype);
 	if (e.options[e.selectedIndex].value == 'person'){
@@ -443,7 +452,7 @@ function addDesc(specid,parentid,pids){
         
         s = document.createElement("span")
         s.id="desc"+newpid+"text"
-        s.appendChild(document.createTextNode(text)) // New description text        
+        s.appendChild(document.createTextNode(escapeHtml(text))) // New description text        
         // Dummy strings to allocate different element variables
         b1 = createButton("b1","edit","Edit","edit",newpid,specid,pids) // New edit button    
         b2 = createButton("b2","edit","Add","add",newpid,specid,pids) // New add button


### PR DESCRIPTION
Potential fix for [https://github.com/clarin-eric/standards/security/code-scanning/1](https://github.com/clarin-eric/standards/security/code-scanning/1)

To fix the problem, we need to ensure that any text content derived from user input is properly escaped before being added to the DOM. This can be achieved by using a function that escapes HTML special characters. We will create a utility function `escapeHtml` to perform this escaping and use it before appending the text node.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
